### PR TITLE
Optimize C++ bigint equality/inequality operators

### DIFF
--- a/cpp/numeric/bigint.cpp
+++ b/cpp/numeric/bigint.cpp
@@ -225,9 +225,9 @@ struct bigint {
 
     bool operator>=(const bigint &v) const { return !(*this < v); }
 
-    bool operator==(const bigint &v) const { return !(*this < v) && !(v < *this); }
+    bool operator==(const bigint &v) const { return sign == v.sign && z == v.z; }
 
-    bool operator!=(const bigint &v) const { return *this < v || v < *this; }
+    bool operator!=(const bigint &v) const { return !(*this == v); }
 
     void trim() {
         while (!z.empty() && z.back() == 0)


### PR DESCRIPTION
No need to run the comparison twice.

Also, starting from the least significant chunk results in a much faster comparison of numbers that are close to each other. It shouldn't influence the other cases, as there's little chance that two numbers with the same number of chunks will differ only in the most significant bits -- if they differ, they will most probably differ in the least significant bits as well.