### PR TITLE
Fixed odd_palindromes in manacher.cpp

### DIFF
--- a/cpp/strings/manacher.cpp
+++ b/cpp/strings/manacher.cpp
@@ -11,7 +11,7 @@ vector<int> odd_palindromes(const string &s) {
     int l = 0;
     int r = -1;
     for (int i = 0; i < n; ++i) {
-        int k = (i > r ? 0 : min(d1[l + r - i], r - i)) + 1;
+        int k = i > r ? 1 : min(d1[l + r - i], r - i);
         while (i + k < n && i - k >= 0 && s[i + k] == s[i - k])
             ++k;
         d1[i] = k--;


### PR DESCRIPTION
`odd_palindromes` produces wrong answer for some inputs. For example, on `"abbba"` it returns `1 1 3 2 1` instead of `1 1 3 1 1`. I believe the problem is that `k` should not be incremented in the second case at line 14. After fixing that it can pass all the test cases I came up with.